### PR TITLE
PAINTROID-95 app name in action bar

### DIFF
--- a/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
+++ b/Paintroid/src/main/java/org/catrobat/paintroid/MainActivity.java
@@ -394,7 +394,8 @@ public class MainActivity extends AppCompatActivity implements MainActivityContr
 		boolean showHome = model.isOpenedFromCatroid();
 		ActionBar supportActionBar = getSupportActionBar();
 		if (supportActionBar != null) {
-			supportActionBar.setDisplayShowTitleEnabled(false);
+			supportActionBar.setDisplayShowTitleEnabled(!isOpenedFromCatroid);
+			supportActionBar.setTitle(R.string.pocketpaint_app_name);
 			supportActionBar.setDisplayHomeAsUpEnabled(true);
 			supportActionBar.setHomeButtonEnabled(true);
 			supportActionBar.setDisplayShowHomeEnabled(showHome);


### PR DESCRIPTION
- displayShowTitle now determined by isOpenedFromCatroid
- Forced the actual appname to be displayed to prevent tests from failing